### PR TITLE
Case-insensitive email search in emailIsTaken

### DIFF
--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -155,7 +155,7 @@ object User {
     * @return a Boolean, true if the email address is already used, false if not
     */
   def emailIsTaken(email: String) = DB.withConnection { implicit c =>
-    val count = SQL("SELECT COUNT(*) FROM users WHERE email={email}").on(
+    val count = SQL("SELECT COUNT(*) FROM users WHERE LOWER(email)=LOWER({email})").on(
       'email -> email
     ).as(scalar[Long].single)
     if (count == 0) false else true

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -155,7 +155,12 @@ object User {
     * @return a Boolean, true if the email address is already used, false if not
     */
   def emailIsTaken(email: String) = DB.withConnection { implicit c =>
-    val count = SQL("SELECT COUNT(*) FROM users WHERE LOWER(email)=LOWER({email})").on(
+    val count = SQL(
+                  """
+                  SELECT COUNT(*) FROM users WHERE
+                  LOWER(email)=LOWER({email})
+                  """
+                ).on(
       'email -> email
     ).as(scalar[Long].single)
     if (count == 0) false else true


### PR DESCRIPTION
Email searches were not case-insensitive; using "test@foo.com" and
"TEST@FOO.COM" let me sign up for two separate accounts.

This is technically a security flaw because a user can theoretically sign up for as many accounts as they have alphabetic characters in their email.
